### PR TITLE
fixed fatal error on save (alert for double alias)

### DIFF
--- a/yams.plugin.inc.php
+++ b/yams.plugin.inc.php
@@ -471,8 +471,8 @@ case 'OnBeforeDocFormSave':
               {
                 $modx->manager->saveFormValues(27);
                 $url = 'index.php?a=27&id=' . $docId;
-                include_once 'header.inc.php';
-                $modx->webAlert(
+                include_once 'webAlertheader.inc.php';
+                $modx->(
                   sprintf(
                     $_lang['duplicate_alias_found']
                     , $duplicateDocId . ' (' . $langId . ')'
@@ -485,7 +485,7 @@ case 'OnBeforeDocFormSave':
                 $modx->manager->saveFormValues(4);
                 $url = 'index.php?a=4';
                 include_once 'header.inc.php';
-                $modx->webAlert(
+                $modx->webAlertAndQuit(
                   sprintf(
                     $_lang['duplicate_alias_found']
                     , $duplicateDocId . ' (' . $langId . ')'
@@ -537,7 +537,7 @@ case 'OnBeforeDocFormSave':
                 $modx->manager->saveFormValues(27);
                 $url = 'index.php?a=27&id=' . $docId;
                 include_once 'header.inc.php';
-                $modx->webAlert(
+                $modx->webAlertAndQuit(
                   sprintf(
                     $_lang['duplicate_alias_found']
                     , $duplicateDocId
@@ -550,7 +550,7 @@ case 'OnBeforeDocFormSave':
                 $modx->manager->saveFormValues(4);
                 $url = 'index.php?a=4';
                 include_once 'header.inc.php';
-                $modx->webAlert(
+                $modx->webAlertAndQuit(
                   sprintf(
                     $_lang['duplicate_alias_found']
                     , $duplicateDocId


### PR DESCRIPTION
»Fatal error: Call to a member function escape() on a non-object«, while checking for double alias entries on save. I changed webAlert() to webAlertAndQuit().
MODx rc3 (41ba52f)
